### PR TITLE
First move of code from Lunchbox: MTQueue, Clock, sleep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Release
 Makefile
 CMakeLists.txt.user*
 CMake/common/
+.tags
+build

--- a/CMake/Extra.cmake
+++ b/CMake/Extra.cmake
@@ -1,0 +1,106 @@
+# Copyright (c) BBP/EPFL 2017
+#                        Stefan.Eilemann@epfl.ch
+
+include(CMakeParseArguments)
+include(GenerateExportHeader)
+
+cmake_policy(SET CMP0020 NEW) # Automatically link Qt executables to qtmain target on Windows.
+cmake_policy(SET CMP0037 NEW) # Target names should not be reserved and should match a validity pattern.
+cmake_policy(SET CMP0038 NEW) # Targets may not link directly to themselves.
+cmake_policy(SET CMP0048 NEW) # The project() command manages VERSION variables.
+cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted.
+
+# WAR for CMake >=3.1 bug (observed with 3.2.3)
+# If not set to false, any call to pkg_check_modules() or pkg_search_module()
+# ERASES the $ENV{PKG_CONFIG_PATH}, so subsequent calls may fail to locate
+# a dependency which depends on this variable (e.g. in FindPoppler.cmake).
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH FALSE)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # -fPIC
+set(CMAKE_INSTALL_MESSAGE LAZY) # no up-to-date messages on installation
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # value of CXX_STANDARD on targets is required
+set_property(GLOBAL PROPERTY USE_FOLDERS ON) # organize targets into folders
+enable_testing()
+
+function(extra_library Name)
+  set(_opts)
+  set(_singleArgs)
+  set(_multiArgs PUBLIC_HEADERS HEADERS SOURCES PUBLIC_LIBRARIES PRIVATE_LIBRARIES)
+  cmake_parse_arguments(THIS "${_opts}" "${_singleArgs}" "${_multiArgs}"
+    ${ARGN})
+  foreach(_multiArg ${_multiArgs})
+    if(THIS_${_multiArg})
+      list(SORT THIS_${_multiArg})
+    endif()
+  endforeach()
+
+  string(TOLOWER ${Name} name)
+  string(TOUPPER ${Name} NAME)
+
+  if(THIS_SOURCES)
+    add_library(${Name} SHARED
+      ${THIS_SOURCES} ${THIS_HEADERS} ${THIS_PUBLIC_HEADERS})
+    set_target_properties(${Name} PROPERTIES
+      VERSION ${${PROJECT_NAME}_VERSION}
+      SOVERSION ${${PROJECT_NAME}_VERSION_ABI}
+      OUTPUT_NAME ${Name} FOLDER ${PROJECT_NAME})
+    target_link_libraries(${Name}
+      PUBLIC ${THIS_PUBLIC_LIBRARIES} PRIVATE ${THIS_PRIVATE_LIBRARIES})
+    generate_export_header(${Name}
+      EXPORT_MACRO_NAME ${NAME}_API EXPORT_FILE_NAME api.h)
+    target_include_directories(${Name} PUBLIC
+      "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>")
+      set_property(TARGET ${Name} PROPERTY CXX_STANDARD 11)
+  else()
+    add_library(${Name} INTERFACE)
+  endif()
+
+  install(TARGETS ${Name}
+    EXPORT ${PROJECT_NAME}Targets
+    ARCHIVE DESTINATION lib COMPONENT dev
+    RUNTIME DESTINATION bin COMPONENT lib
+    LIBRARY DESTINATION lib COMPONENT lib
+    INCLUDES DESTINATION include)
+  foreach(_header ${THIS_PUBLIC_HEADERS})
+    string(REGEX MATCH "(.*)[/\\]" _dir ${_header})
+    install(FILES ${_header} DESTINATION include/${name}/${_dir})
+  endforeach()
+endfunction()
+
+function(extra_test Name)
+  if(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY)
+    return()
+  endif()
+  if(NOT WIN32) # tests want to be with DLLs on Windows - no rpath support
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
+
+  set(_opts)
+  set(_singleArgs)
+  set(_multiArgs SOURCES LIBRARIES)
+  cmake_parse_arguments(THIS "${_opts}" "${_singleArgs}" "${_multiArgs}"
+    ${ARGN})
+  foreach(_multiArg ${_multiArgs})
+    if(THIS_${_multiArg})
+      list(SORT THIS_${_multiArg})
+    endif()
+  endforeach()
+
+  add_executable(${Name} ${THIS_SOURCES})
+  target_link_libraries(${Name} ${THIS_LIBRARIES}
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  target_include_directories(${Name} PRIVATE
+    "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+    BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
+  target_compile_definitions(${Name} PRIVATE -DBOOST_TEST_DYN_LINK)
+  set_property(TARGET ${Name} PROPERTY CXX_STANDARD 11)
+
+  add_test(NAME ${Name}
+    COMMAND $<TARGET_FILE:${Name}>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright (c) BBP/EPFL 2017 Stefan.Eilemann@epfl.ch
+# Copyright (c) BBP/EPFL 2017
+#                        Stefan.Eilemann@epfl.ch
 
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
 project(Extra VERSION 1.0.0)

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -1,4 +1,15 @@
 # Copyright (c) BBP/EPFL 2017
 #                        Stefan.Eilemann@epfl.ch
 
-extra_library(Extra HEADERS SOURCES)
+extra_library(Extra
+  PUBLIC_HEADERS
+    clock.h
+    mtQueue.h
+    mtQueue.ipp
+    sleep.h
+    time.h
+    types.h
+  SOURCES
+    clock.cpp
+    sleep.cpp
+  )

--- a/extra/clock.cpp
+++ b/extra/clock.cpp
@@ -1,0 +1,186 @@
+
+/* Copyright (c) 2010-2017, Stefan Eilemann <eile@eyescale.ch>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "clock.h"
+
+#ifdef __APPLE__
+// http://developer.apple.com/qa/qa2004/qa1398.html
+#include <mach/mach_time.h>
+#endif
+
+#ifndef _WIN32
+#include <time.h>
+#endif
+
+namespace extra
+{
+class Clock::Impl
+{
+public:
+#ifdef __APPLE__
+    uint64_t start;
+    mach_timebase_info_data_t timebaseInfo;
+#elif defined(_WIN32)
+    LARGE_INTEGER start;
+    LARGE_INTEGER frequency;
+#else
+    struct timespec start;
+#endif
+};
+
+Clock::Clock()
+    : _impl(new Clock::Impl)
+{
+    reset();
+#ifdef __APPLE__
+    mach_timebase_info(&_impl->timebaseInfo);
+#elif defined(_WIN32)
+    QueryPerformanceFrequency(&_impl->frequency);
+#endif
+}
+
+Clock::Clock(const Clock& from)
+    : _impl(new Clock::Impl(*from._impl))
+{
+}
+
+Clock& Clock::operator=(const Clock& ref)
+{
+    *_impl = *ref._impl;
+    return *this;
+}
+
+Clock::~Clock()
+{
+    delete _impl;
+}
+
+void Clock::reset()
+{
+#ifdef __APPLE__
+    _impl->start = mach_absolute_time();
+#elif defined(_WIN32)
+    QueryPerformanceCounter(&_impl->start);
+#else
+    clock_gettime(CLOCK_REALTIME, &_impl->start);
+#endif
+}
+
+void Clock::set(const int64_t time)
+{
+    reset();
+#ifdef __APPLE__
+    _impl->start -= static_cast<uint64_t>(time * _impl->timebaseInfo.denom /
+                                          _impl->timebaseInfo.numer * 1000000);
+#elif defined(_WIN32)
+    _impl->start.QuadPart -=
+        static_cast<long long>(time * _impl->frequency.QuadPart / 1000);
+#else
+    const int sec = static_cast<int>(time / 1000) + 1;
+    _impl->start.tv_sec -= sec;
+    _impl->start.tv_nsec -= static_cast<int>((time - sec * 1000) * 1000000);
+    if (_impl->start.tv_nsec > 1000000000)
+    {
+        _impl->start.tv_sec += 1;
+        _impl->start.tv_nsec -= 1000000000;
+    }
+#endif
+}
+
+float Clock::getTimef() const
+{
+#ifdef __APPLE__
+    const int64_t elapsed = mach_absolute_time() - _impl->start;
+    return (elapsed * _impl->timebaseInfo.numer / _impl->timebaseInfo.denom /
+            1000000.f);
+#elif defined(_WIN32)
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    return 1000.0f * (now.QuadPart - _impl->start.QuadPart) /
+           _impl->frequency.QuadPart;
+#else
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    return (1000.0f * (now.tv_sec - _impl->start.tv_sec) +
+            0.000001f * (now.tv_nsec - _impl->start.tv_nsec));
+#endif
+}
+
+float Clock::resetTimef()
+{
+#ifdef __APPLE__
+    const uint64_t now = mach_absolute_time();
+    const int64_t elapsed = now - _impl->start;
+    const float time = elapsed * _impl->timebaseInfo.numer /
+                       _impl->timebaseInfo.denom / 1000000.f;
+#elif defined(_WIN32)
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    const float time = 1000.0f * (now.QuadPart - _impl->start.QuadPart) /
+                       _impl->frequency.QuadPart;
+#else
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    const float time = (1000.0f * (now.tv_sec - _impl->start.tv_sec) +
+                        0.000001f * (now.tv_nsec - _impl->start.tv_nsec));
+#endif
+    _impl->start = now;
+    return time;
+}
+
+int64_t Clock::getTime64() const
+{
+#ifdef __APPLE__
+    const int64_t elapsed = mach_absolute_time() - _impl->start;
+    return (elapsed * _impl->timebaseInfo.numer / _impl->timebaseInfo.denom +
+            500000) /
+           1000000;
+#elif defined(_WIN32)
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    return (1000 * (now.QuadPart - _impl->start.QuadPart) +
+            (_impl->frequency.QuadPart >> 1)) /
+           _impl->frequency.QuadPart;
+#else
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    return (1000 * (now.tv_sec - _impl->start.tv_sec) +
+            int64_t(0.000001f * (now.tv_nsec - _impl->start.tv_nsec + 500000)));
+#endif
+}
+
+double Clock::getTimed() const
+{
+#ifdef __APPLE__
+    const int64_t elapsed = mach_absolute_time() - _impl->start;
+    return (elapsed * _impl->timebaseInfo.numer / _impl->timebaseInfo.denom /
+            1000000.);
+#elif defined(_WIN32)
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+    return 1000.0 * (now.QuadPart - _impl->start.QuadPart) /
+           _impl->frequency.QuadPart;
+#else
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME, &now);
+    return (1000.0 * (now.tv_sec - _impl->start.tv_sec) +
+            0.000001 * (now.tv_nsec - _impl->start.tv_nsec));
+#endif
+}
+}

--- a/extra/clock.h
+++ b/extra/clock.h
@@ -1,0 +1,81 @@
+
+/* Copyright (c) 2005-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <extra/api.h>
+#include <extra/types.h>
+
+namespace extra
+{
+/** A class for time measurements. */
+class Clock
+{
+public:
+    /** Construct a new clock. @version 1.0 */
+    EXTRA_API Clock();
+
+    /** Copy-construct a new clock with the same start time . @version 1.0 */
+    EXTRA_API Clock(const Clock& from);
+
+    /** Destroy the clock. @version 1.0 */
+    EXTRA_API ~Clock();
+
+    /** Assignment operator. @version 1.7.2 */
+    EXTRA_API Clock& operator=(const Clock& ref);
+
+    /**
+     * Reset the base time of the clock to the current time.
+     * @version 1.0
+     */
+    EXTRA_API void reset();
+
+    /** Set the current time of the clock. @version 1.0 */
+    EXTRA_API void set(const int64_t time);
+
+    /**
+     * @return the elapsed time in milliseconds since the last clock reset.
+     * @version 1.0
+     */
+    EXTRA_API float getTimef() const;
+
+    /**
+     * @return the elapsed time in milliseconds since the last clock reset
+     *         and atomically reset the clock.
+     * @version 1.0
+     */
+    EXTRA_API float resetTimef();
+
+    /**
+     * @return the elapsed time in milliseconds since the last clock reset.
+     * @version 1.0
+     */
+    EXTRA_API int64_t getTime64() const;
+
+    /**
+     * @return the elapsed time in milliseconds since the last clock reset.
+     * @version 1.0
+     */
+    EXTRA_API double getTimed() const;
+
+private:
+    class Impl;
+    Impl* const _impl;
+};
+}

--- a/extra/mtQueue.h
+++ b/extra/mtQueue.h
@@ -1,0 +1,219 @@
+
+/* Copyright (c) 2005-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <limits.h>
+#include <mutex>
+#include <queue>
+#include <string.h>
+
+namespace extra
+{
+/**
+ * A thread-safe queue with a blocking read access.
+ *
+ * Typically used to communicate between two execution threads.
+ *
+ * S is deprecated by the ctor param maxSize, and defines the initial maximum
+ * capacity of the Queue<T>.  When the capacity is reached, pushing new values
+ * blocks until items have been consumed.
+ *
+ * Example: @include tests/mtQueue.cpp
+ */
+template <typename T, size_t S = ULONG_MAX>
+class MTQueue
+// S = std::numeric_limits< size_t >::max() does not work:
+//   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=6424
+{
+public:
+    class Group;
+    typedef T value_type;
+
+    /** Construct a new queue. @version 1.0 */
+    explicit MTQueue(const size_t maxSize = S)
+        : _maxSize(maxSize)
+    {
+    }
+
+    /** Construct a copy of a queue. @version 1.0 */
+    MTQueue(const MTQueue<T, S>& from) { *this = from; }
+    /** Destruct this Queue. @version 1.0 */
+    ~MTQueue() {}
+    /** Assign the values of another queue. @version 1.0 */
+    MTQueue<T, S>& operator=(const MTQueue<T, S>& from);
+
+    /**
+     * Retrieve the requested element from the queue, may block.
+     * @version 1.3.2
+     */
+    const T& operator[](const size_t index) const;
+
+    /** @return true if the queue is empty, false otherwise. @version 1.0 */
+    bool isEmpty() const { return _queue.empty(); }
+    /** @return the number of items currently in the queue. @version 1.0 */
+    size_t getSize() const { return _queue.size(); }
+    /**
+     * Set the new maximum size of the queue.
+     *
+     * If the new maximum size is less the current size of the queue, this
+     * call will block until the queue reaches the new maximum size.
+     *
+     * @version 1.3.2
+     */
+    void setMaxSize(const size_t maxSize);
+
+    /** @return the current maximum size of the queue. @version 1.3.2 */
+    size_t getMaxSize() const { return _maxSize; }
+    /**
+     * Wait for the size to be at least the number of given elements.
+     *
+     * @return the current size when the condition was fulfilled.
+     * @version 1.0
+     */
+    size_t waitSize(const size_t minSize) const;
+
+    /** Reset (empty) the queue. @version 1.0 */
+    void clear();
+
+    /**
+     * Retrieve and pop the front element from the queue, may block.
+     * @version 1.0
+     */
+    T pop();
+
+    /**
+     * Retrieve and pop the front element from the queue.
+     *
+     * @param timeout the timeout
+     * @param element the element returned
+     * @return true if an element was popped
+     * @version 1.1
+     */
+    bool timedPop(const unsigned timeout, T& element);
+
+    /**
+     * Retrieve a number of items from the front of the queue.
+     *
+     * Between minimum and maximum number of items are returned in a vector. If
+     * the queue has less than minimum number of elements on timeout, the result
+     * vector is empty. The method returns as soon as there are at least minimum
+     * elements available, i.e., it does not wait for the maximum to be reached.
+     *
+     * Note that this method might block up to 'minimum * timeout' milliseconds,
+     * that is, the timeout defines the time to wait for an update on the queue.
+     *
+     * @param timeout the timeout to wait for an update
+     * @param minimum the minimum number of items to retrieve
+     * @param maximum the maximum number of items to retrieve
+     * @return an empty vector on timeout, otherwise the result vector
+     *         containing between minimum and maximum elements.
+     * @version 1.7.0
+     */
+    std::vector<T> timedPopRange(const unsigned timeout,
+                                 const size_t minimum = 1,
+                                 const size_t maximum = S);
+
+    /**
+     * Retrieve and pop the front element from the queue if it is not empty.
+     *
+     * @param result the front value or unmodified.
+     * @return true if an element was placed in result, false if the queue
+     *         is empty.
+     * @version 1.0
+     */
+    bool tryPop(T& result);
+
+    /**
+     * Try to retrieve a number of items from the front of the queue.
+     *
+     * Between zero and the given number of items are appended to the vector.
+     *
+     * @param num the maximum number of items to retrieve
+     * @param result the front value or unmodified.
+     * @return true if an element was placed in result, false if the queue
+     *         is empty.
+     * @version 1.1.6
+     */
+    void tryPop(const size_t num, std::vector<T>& result);
+
+    /**
+     * Retrieve the front element, or abort if the barrier is reached
+     *
+     * Used for worker threads recursively processing data, pushing it back the
+     * queue. Either returns an item from the queue, or aborts if num
+     * participants are waiting in the queue.
+     *
+     * @param result the result element, unmodified on false return value.
+     * @param barrier the group's barrier handle.
+     * @return true if an element was retrieved, false if the barrier height
+     *         was reached.
+     * @version 1.7.1
+     */
+    bool popBarrier(T& result, Group& barrier);
+
+    /**
+     * @param result the front value or unmodified.
+     * @return true if an element was placed in result, false if the queue
+     *         is empty.
+     * @version 1.0
+     */
+    bool getFront(T& result) const;
+
+    /**
+     * @param result the last value or unmodified.
+     * @return true if an element was placed in result, false if the queue
+     *         is empty.
+     * @version 1.0
+     */
+    bool getBack(T& result) const;
+
+    /** Push a new element to the back of the queue. @version 1.0 */
+    void push(const T& element);
+
+    /** Push a vector of elements to the back of the queue. @version 1.0 */
+    void push(const std::vector<T>& elements);
+
+    /** Push a new element to the front of the queue. @version 1.0 */
+    void pushFront(const T& element);
+
+    /** Push a vector of elements to the front of the queue. @version 1.0 */
+    void pushFront(const std::vector<T>& elements);
+
+    /** @name STL compatibility. @version 1.7.1 */
+    //@{
+    void push_back(const T& element) { push(element); }
+    bool empty() const { return isEmpty(); }
+    //@}
+
+private:
+    MTQueue(MTQueue<T, S>&&) = delete;
+    MTQueue<T, S>& operator=(MTQueue<T, S>&&) = delete;
+
+    std::deque<T> _queue;
+    mutable std::mutex _mutex;
+    mutable std::condition_variable _condition;
+    size_t _maxSize;
+};
+}
+
+#include "mtQueue.ipp" // template implementation

--- a/extra/mtQueue.ipp
+++ b/extra/mtQueue.ipp
@@ -1,0 +1,268 @@
+
+/* Copyright (c) 2005-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace extra
+{
+template <typename T, size_t S>
+MTQueue<T, S>& MTQueue<T, S>::operator=(const MTQueue<T, S>& from)
+{
+    if (this == &from)
+        return *this;
+
+    std::unique_lock<std::mutex> fromLock(from._mutex);
+    std::deque<T> copy = from._queue;
+    const size_t maxSize = from._maxSize;
+    fromLock.unlock();
+
+    std::unique_lock<std::mutex> lock(_mutex);
+    _maxSize = maxSize;
+    _queue.swap(copy);
+    _condition.notify_all();
+    return *this;
+}
+
+template <typename T, size_t S>
+const T& MTQueue<T, S>::operator[](const size_t index) const
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return _queue.size() > index; });
+
+    return _queue[index];
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::setMaxSize(const size_t maxSize)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return _queue.size() <= maxSize; });
+
+    _maxSize = maxSize;
+    _condition.notify_all();
+}
+
+template <typename T, size_t S>
+size_t MTQueue<T, S>::waitSize(const size_t minSize) const
+{
+    LBASSERT(minSize <= _maxSize);
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return _queue.size() >= minSize; });
+    return _queue.size();
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::clear()
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _queue.clear();
+    _condition.notify_all();
+}
+
+template <typename T, size_t S>
+T MTQueue<T, S>::pop()
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return !_queue.empty(); });
+
+    T element = _queue.front();
+    _queue.pop_front();
+    _condition.notify_all();
+    return element;
+}
+
+template <typename T, size_t S>
+bool MTQueue<T, S>::timedPop(const unsigned timeout, T& element)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait_for(lock, std::chrono::milliseconds(timeout),
+                        [&] { return !_queue.empty(); });
+    if (_queue.empty())
+        return false;
+
+    element = _queue.front();
+    _queue.pop_front();
+    _condition.notify_all();
+    return true;
+}
+
+template <typename T, size_t S>
+std::vector<T> MTQueue<T, S>::timedPopRange(const unsigned timeout,
+                                            const size_t minimum,
+                                            const size_t maximum)
+{
+    std::vector<T> result;
+
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait_for(lock, std::chrono::milliseconds(timeout),
+                        [&] { return _queue.size() >= minimum; });
+    if (_queue.size() < minimum)
+        return result;
+
+    const size_t size = LB_MIN(maximum, _queue.size());
+
+    result.reserve(size);
+    result.insert(result.end(), _queue.begin(), _queue.begin() + size);
+    _queue.erase(_queue.begin(), _queue.begin() + size);
+
+    _condition.notify_all();
+    return result;
+}
+
+template <typename T, size_t S>
+bool MTQueue<T, S>::tryPop(T& result)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty())
+        return false;
+
+    result = _queue.front();
+    _queue.pop_front();
+    _condition.notify_all();
+    return true;
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::tryPop(const size_t num, std::vector<T>& result)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    const size_t size = LB_MIN(num, _queue.size());
+    if (size > 0)
+    {
+        result.reserve(result.size() + size);
+        for (size_t i = 0; i < size; ++i)
+        {
+            result.push_back(_queue.front());
+            _queue.pop_front();
+        }
+        _condition.notify_all();
+    }
+}
+
+/** Group descriptor for popBarrier(). @version 1.7.1 */
+template <typename T, size_t S>
+class MTQueue<T, S>::Group
+{
+    friend class MTQueue<T, S>;
+    size_t height_;
+    size_t waiting_;
+
+public:
+    /**
+     * Construct a new group of the given size. Can only be used once.
+     * @version 1.7.1
+     */
+    explicit Group(const size_t height)
+        : height_(height)
+        , waiting_(0)
+    {
+    }
+
+    /** Update the height. @version 1.7.1  */
+    void setHeight(const size_t height) { height_ = height; }
+};
+
+template <typename T, size_t S>
+bool MTQueue<T, S>::popBarrier(T& element, Group& barrier)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    ++barrier.waiting_;
+    _condition.wait(lock, [&] {
+        return !_queue.empty() || barrier.waiting_ >= barrier.height_;
+    });
+
+    if (_queue.empty())
+    {
+        _condition.notify_all();
+        return false;
+    }
+
+    element = _queue.front();
+    _queue.pop_front();
+    --barrier.waiting_;
+    _condition.notify_all();
+    return true;
+}
+
+template <typename T, size_t S>
+bool MTQueue<T, S>::getFront(T& result) const
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty())
+        return false;
+
+    // else
+    result = _queue.front();
+    return true;
+}
+
+template <typename T, size_t S>
+bool MTQueue<T, S>::getBack(T& result) const
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    if (_queue.empty())
+        return false;
+
+    // else
+    result = _queue.back();
+    return true;
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::push(const T& element)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return _queue.size() < _maxSize; });
+    _queue.push_back(element);
+    _condition.notify_all();
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::push(const std::vector<T>& elements)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] {
+        return (_maxSize - _queue.size()) >= elements.size();
+    });
+    ;
+    _queue.insert(_queue.end(), elements.begin(), elements.end());
+    _condition.notify_all();
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::pushFront(const T& element)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] { return _queue.size() < _maxSize; });
+    ;
+    _queue.push_front(element);
+    _condition.notify_all();
+}
+
+template <typename T, size_t S>
+void MTQueue<T, S>::pushFront(const std::vector<T>& elements)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _condition.wait(lock, [&] {
+        return (_maxSize - _queue.size()) >= elements.size();
+    });
+    ;
+    _queue.insert(_queue.begin(), elements.begin(), elements.end());
+    _condition.notify_all();
+}
+}

--- a/extra/sleep.cpp
+++ b/extra/sleep.cpp
@@ -1,0 +1,37 @@
+
+/* Copyright (c) 2011-2017, Stefan Eilemann <eile@eyescale.ch>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "sleep.h"
+
+#include <extra/time.h>
+
+namespace extra
+{
+void sleep(const uint32_t milliSeconds)
+{
+#ifdef _WIN32 //_MSC_VER
+    ::Sleep(milliSeconds);
+#else
+    timespec ts = convertToTimespec(milliSeconds);
+    while (::nanosleep(&ts, &ts) != 0) // -1 on signal (#4)
+        if (ts.tv_sec <= 0 && ts.tv_nsec <= 0)
+            return;
+#endif
+}
+}

--- a/extra/sleep.h
+++ b/extra/sleep.h
@@ -1,0 +1,33 @@
+
+/* Copyright (c) 2008-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <extra/api.h>
+#include <extra/types.h>
+
+namespace extra
+{
+/**
+ * Sleep the current thread for a number of milliseconds.
+ * @version 1.0
+ * @deprecated Use boost::this_thread::sleep()
+ */
+EXTRA_API void sleep(const uint32_t milliSeconds);
+}

--- a/extra/time.h
+++ b/extra/time.h
@@ -1,0 +1,37 @@
+
+/* Copyright (c) 2012-2017, Stefan Eilemann <eile@eyescale.ch>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+#ifndef _MSC_VER
+
+#include <extra/types.h>
+#include <time.h>
+
+namespace extra
+{
+/** @internal @return a millisecond time as a unix timespec. */
+inline timespec convertToTimespec(const uint32_t milliSeconds)
+{
+    timespec ts = {0, 0};
+    ts.tv_sec = static_cast<int>(milliSeconds / 1000);
+    ts.tv_nsec = (milliSeconds - ts.tv_sec * 1000) * 1000000;
+    return ts;
+}
+}
+#endif

--- a/extra/types.h
+++ b/extra/types.h
@@ -1,0 +1,67 @@
+
+/* Copyright (c) 2007-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 2.1 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @file lunchbox/types.h
+ * Basic type definitions not provided by the standard, forward declarations of
+ * Extra types.
+ */
+
+/**
+ * @namespace extra
+ * @brief Abstraction layer and common utilities for C++ programming.
+ *
+ * Extra provides C++ classes to abstract the underlying operating system and
+ * to implement common utilities for multi-threaded C++ programs. It does not
+ * have any requirements beyond C++11 and standard system headers.
+ */
+
+#pragma once
+
+#include <sys/types.h>
+
+#ifndef _MSC_VER
+#include <stdint.h>
+#endif
+
+#ifdef _WIN32
+#include <basetsd.h>
+
+#ifdef _MSC_VER
+typedef UINT64 uint64_t;
+typedef INT64 int64_t;
+typedef UINT32 uint32_t;
+typedef INT32 int32_t;
+typedef UINT16 uint16_t;
+typedef INT16 int16_t;
+typedef UINT8 uint8_t;
+typedef INT8 int8_t;
+
+#ifndef HAVE_SSIZE_T
+typedef SSIZE_T ssize_t;
+#define HAVE_SSIZE_T
+#endif
+
+#endif // Win32, Visual C++
+#endif // Win32
+
+namespace extra
+{
+class Clock;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,5 @@
 #                        Stefan.Eilemann@epfl.ch
 # Change this number when adding tests to force a CMake run: 0
 
-set(TEST_LIBRARIES ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} Hello)
+extra_test(clock SOURCES clock.cpp LIBRARIES ${BUT_LIB} Extra)
+extra_test(mtQueue SOURCES mtQueue.cpp LIBRARIES ${BUT_LIB} Extra)

--- a/tests/clock.cpp
+++ b/tests/clock.cpp
@@ -1,0 +1,56 @@
+
+/* Copyright (c) 2014-2017, Stefan.Eilemann@epfl.ch
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of Eyescale Software GmbH nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <extra/clock.h>
+#include <extra/sleep.h>
+
+#define BOOST_TEST_MODULE Clock
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(copy)
+{
+    extra::Clock clock;
+    extra::Clock copy(clock);
+
+    BOOST_CHECK_LE(clock.getTimef() - copy.getTimef(), 0.f);
+    BOOST_CHECK_GT(clock.getTimef() - copy.getTimef(), -1.f);
+}
+
+BOOST_AUTO_TEST_CASE(timing)
+{
+    extra::Clock clock;
+    extra::sleep(10.f);
+    BOOST_CHECK_GT(clock.resetTimef(), 0.f);
+
+    extra::sleep(100.f);
+    BOOST_CHECK_GT(clock.getTimef(), 99.f);
+    BOOST_CHECK_LT(clock.getTimef(), 110.f);
+    BOOST_CHECK_LT(clock.getTimed(), 110.f);
+}

--- a/tests/mtQueue.cpp
+++ b/tests/mtQueue.cpp
@@ -1,0 +1,82 @@
+
+/* Copyright (c) 2010-2017, Stefan Eilemann <eile@equalizergraphics.com>
+ *                          Daniel Nachbaur <danielnachbaur@gmail.com>
+ *
+ * This file is part of Extra <https://github.com/BlueBrain/Extra>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of Eyescale Software GmbH nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <extra/clock.h>
+#include <extra/mtQueue.h>
+#include <iostream>
+#include <thread>
+
+#define BOOST_TEST_MODULE MTQueue
+#include <boost/test/unit_test.hpp>
+
+#define NOPS 100000
+#define NTHREADS 4
+
+extra::MTQueue<uint64_t> queue;
+extra::MTQueue<uint64_t>::Group group(NTHREADS + 1);
+
+#ifdef LB_GCC_4_6_OR_LATER
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+static void read()
+{
+    uint64_t item = 0xffffffffffffffffull;
+#ifndef NDEBUG
+    uint64_t last = 0;
+#endif
+    while (queue.popBarrier(item, group))
+    {
+#ifndef NDEBUG
+        BOOST_CHECK_LT(last, item);
+        last = item;
+#endif
+    }
+    BOOST_CHECK(queue.isEmpty());
+}
+
+BOOST_AUTO_TEST_CASE(perf)
+{
+    std::vector<std::thread> readers;
+    while (readers.size() < NTHREADS)
+        readers.emplace_back(std::thread([] { read(); }));
+
+    extra::Clock clock;
+    for (size_t i = 1; i < NOPS; ++i)
+        queue.push(i);
+    const float time = clock.getTimef();
+
+    read();
+
+    for (size_t i = 0; i < NTHREADS; ++i)
+        readers[i].join();
+
+    std::cout << NOPS / time << " writes/ms" << std::endl;
+}


### PR DESCRIPTION
At this point this is just a discussion point, we'll merge this after
the release (and when everybody is happy). Any functionality in this
library is not to be replicated in our projects.

The main ideas are:
* Create a new 'Lunchbox lite' which only depends on the compiler and
  system headers
* Separate the user and developer cmake scripts, making the first as
  simple and robust as possible

To be done are:
* Make the Extra.cmake auto-update as GitExternal
* Make (a new?) CMake/common which augments Extra with the stuff we want
  (warnings, doxygen, etc), to be cloned optionally into the repo
* Move more functionality from Lunchbox as needed